### PR TITLE
Re-check spec tests and remove rogue prys

### DIFF
--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -1,28 +1,17 @@
-
-
-
-
-# require './lib/card_generator'
-# filename = "cards.txt"
-
-
-
-
-
 class Gameplay
   def start
-    cards = CardGenerator.new('./cards.txt')
-    cards.create_cards
-    deck = Deck.new(cards)
+    all_cards = CardGenerator.new('./cards.txt')
+    all_cards.create_cards
+    deck = Deck.new(all_cards)
 
     # binding.pry
     # deck.create_cards
 
 
-    deck.cards.cards.shuffle!
+    deck.all_cards.cards.shuffle!
 
-    deck1 = Deck.new(deck.cards.cards[0..25])
-    deck2 = Deck.new(deck.cards.cards[26..51])
+    deck1 = Deck.new(deck.all_cards.cards[0..25])
+    deck2 = Deck.new(deck.all_cards.cards[26..51])
 
     player1 = Player.new("Megan", deck1)
     player2 = Player.new("Aurora", deck2)
@@ -31,14 +20,12 @@ class Gameplay
     # binding.pry
     turn_counter = 0
     until player1.has_lost? == true || player2.has_lost? == true || turn_counter == 1000000 do
-
-
       turn_counter += 1
       # binding.pry
       if turn.type == :mutually_assured_destruction && turn.type != :basic
         turn.pile_cards
           puts "Turn #{turn_counter}: *mutually assured destruction* 6 cards removed from play"
-          # sleep(0.02)
+          sleep(1)
       elsif turn.type == :war
         turn.winner
         turn.pile_cards
@@ -48,7 +35,7 @@ class Gameplay
           puts "Turn #{turn_counter}: WAR - #{player2.name} won #{turn.spoils_of_war.length} cards"
         end
         turn.award_spoils
-        # sleep(0.02)
+        sleep(0.02)
       elsif turn.type == :basic && turn.type != :mutually_assured_destruction
         turn.winner
         turn.pile_cards
@@ -58,7 +45,7 @@ class Gameplay
           puts "Turn #{turn_counter}: #{player2.name} won #{turn.spoils_of_war.length} cards"
         end
         turn.award_spoils
-        # sleep(0.02)
+        sleep(0.02)
       end
     end
 

--- a/spec/card_generator_spec.rb
+++ b/spec/card_generator_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe CardGenerator do
   it 'can generate_cards' do
     deck = CardGenerator.new('./cards.txt')
     deck.create_cards
-    # binding.pry
     expect(deck.cards[0].suit).to eq(:club)
   end
 
@@ -18,7 +17,6 @@ RSpec.describe CardGenerator do
     cards = CardGenerator.new('./cards.txt')
     cards.create_cards
     deck = Deck.new(cards)
-    # binding.pry
     expect(deck.cards.cards[0].suit).to eq(:club)
   end
 
@@ -26,6 +24,6 @@ RSpec.describe CardGenerator do
     deck = CardGenerator.new('./cards.txt')
     deck.create_cards
     deck.cards.shuffle!
-    expect(deck.cards[0].rank).to be == 2
+    expect(deck.cards[0].rank && deck.cards[13].rank && deck.cards[26].rank && deck.cards[39].rank).not_to eq(2)
   end
 end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -15,5 +15,4 @@ RSpec.describe Card do
     expect(card.value).to eq('Queen')
     expect(card.rank).to eq(12)
   end
-  # require "pry";binding.pry
 end

--- a/spec/deck_spec.rb
+++ b/spec/deck_spec.rb
@@ -12,7 +12,6 @@ require 'pry'
    it 'is made up of an array of cards' do
      deck = Deck.new(cards)
      expect(deck.cards).to eq([card1, card2, card3])
-     # binding.pry
    end
 
    it 'can determine card ranking & percentage of high ranking cards' do
@@ -32,7 +31,6 @@ require 'pry'
     it 'removes from high ranking list' do
       deck = Deck.new(cards)
       removed = deck.remove_card
-      # binding.pry
       expect(deck.high_ranking_cards.include?(removed)).to eq(false)
     end
    end

--- a/spec/gameplay_spec.rb
+++ b/spec/gameplay_spec.rb
@@ -21,17 +21,14 @@ player1 = Player.new("Megan", deck1)
 player2 = Player.new("Aurora", deck2)
 
 turn = Turn.new(player1, player2)
-# binding.pry
 turn_counter = 0
 until player1.has_lost? == true || player2.has_lost? == true || turn_counter == 1000000 do
 
 turn_counter += 1
 turn.spoils_of_war.clear
-# binding.pry
   if turn.type == :mutually_assured_destruction && turn.type != :basic
     turn.pile_cards
-    puts "kjhjbhfkhfjwefcjkhskfhkjefhkfkhsfkjsdkjhffskdksd"
-    binding.pry
+    puts "mutually assured destruction"
   elsif turn.type == :war
     turn.winner
     turn.pile_cards

--- a/spec/player_spec.rb
+++ b/spec/player_spec.rb
@@ -12,13 +12,11 @@ RSpec.describe Player do
 
     it 'has a name and a deck' do
       player = Player.new('Clarisa', deck)
-      # binding.pry
       expect(player.name).to eq('Clarisa')
       expect(player.deck).to eq(deck)
     end
     it 'can determine if it has lost' do
       player = Player.new('Clarisa', deck)
-      # binding.pry
       expect(player.has_lost?).to eq(false)
       player.deck.remove_card
       expect(player.has_lost?).to eq(false)
@@ -27,14 +25,6 @@ RSpec.describe Player do
       player.deck.remove_card
       expect(player.has_lost?).to eq(true)
       expect(player.deck.cards).to eq([])
-    end
-  end
-
-  context 'test' do
-    it 'can create a card' do
-      test_deck = Deck.new
-      test_deck.create_card(1, :diamond, 'Queen', 12)
-      expect(test_deck.card1.value).to eq('Queen')
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Turn do
     player2 = Player.new("Aurora", deck2)
 
     turn = Turn.new(player1, player2)
-    # binding.pry
 
     it 'can determine who its 2 players are' do
       expect(turn.player1.name).to eq("Megan")
@@ -43,7 +42,6 @@ RSpec.describe Turn do
     end
 
     it 'can give the winner the spoils of war' do
-      # binding.pry
       turn.pile_cards
       turn.award_spoils
       expect(player1.deck.cards.count).to eq(6)
@@ -119,5 +117,3 @@ RSpec.describe Turn do
     end
   end
 end
-
-# binding.pry

--- a/war_or_peace_runner.rb
+++ b/war_or_peace_runner.rb
@@ -13,7 +13,6 @@ puts "The players today are Morgan and Aurora."
 puts "Type 'GO' to start the game!"
 puts "------------------------------------------------------------------"
 ready = gets.chomp.upcase
-# binding.pry
 if ready == 'GO'
   go.start
 else


### PR DESCRIPTION
There is an incredibly slim chance the spec test "CardGenerator can shuffle" will fail as the only way I could think to test it would be to check if specific card positions had moved and, due to the random nature of shuffling, all 4 card positions being checked could _technically_ still land in the same spot. 